### PR TITLE
Allow 2d translations

### DIFF
--- a/packages/Style_/src/index.tsx
+++ b/packages/Style_/src/index.tsx
@@ -29,6 +29,7 @@ export interface IProps {
   // transforms
   translateX?: string,
   translateY?: string,
+  translate?: string,
   scale?: string,
   scaleX?: string,
   scaleY?: string,
@@ -77,6 +78,7 @@ const TRANSFORM_STYLE_PROPERTIES = [
   'skewY',
   'translateX',
   'translateY',
+  'translate',
 ]
 
 


### PR DESCRIPTION
This will allow 2d translations of the form `translate='2px 2px'`