### PR TITLE
abstract tweening, scrollToY takes target element

### DIFF
--- a/packages/dom/src/index.js.flow
+++ b/packages/dom/src/index.js.flow
@@ -1,7 +1,7 @@
 declare module "constelation-dom" {
   declare export function disableScroll(): void;
   declare export function enableScroll(): void;
-  declare export function scrollToY(endY?: number, speed?: number, easing?: string): void;
+  declare export function scrollToY(endY?: number, speed?: number, easing?: string, element?: Element): void;
   declare export function getScrollTop(): number;
   declare export function getElementOffsetTop(element: HTMLElement): number;
 }

--- a/packages/dom/src/index.tsx
+++ b/packages/dom/src/index.tsx
@@ -57,17 +57,15 @@ export function enableScroll() {
 }
 
 //from http://stackoverflow.com/questions/8917921/cross-browser-javascript-not-jquery-scroll-to-top-animation
-// scrollTargetY: the target scrollY property of the window
+// finalDelta: the total amount to change the value (final - initial)
 // speed: time in pixels per second
 // easing: easing equation to use
-export function scrollToY(endY = 0, speed = 2000, easing = 'easeInOutQuint') {
+function tweenValue(finalDelta: number, callback: Function, speed = 2000, easing = 'easeInOutQuint') {
   const startTime = window.performance.now()
-
-  const startY = window.scrollY
 
   // min time 100ms, max time 800ms
   const time =
-    Math.max(0.1, Math.min(Math.abs(startY - endY) / speed, 0.8)) * 1000
+    Math.max(0.1, Math.min(Math.abs(finalDelta) / speed, 0.8)) * 1000
 
   function tick(currentTime: number) {
     const elapsedTime = currentTime - startTime
@@ -78,15 +76,25 @@ export function scrollToY(endY = 0, speed = 2000, easing = 'easeInOutQuint') {
     if (progress < 1) {
       window.requestAnimationFrame(tick)
 
-      window.scrollTo(0, startY + (endY - startY) * t)
+      callback(finalDelta * t)
     }
     else {
-      window.scrollTo(0, endY)
+      callback(finalDelta)
     }
   }
 
   // call it once to get started
   window.requestAnimationFrame(tick)
+}
+
+export function scrollToY(endY = 0, speed = 2000, easing = 'easeInOutQuint', element = window.document.scrollingElement) {
+  const startY = element.scrollTop
+
+  function scrollMove(movement: number) {
+    element.scrollTop = startY + movement
+  }
+
+  tweenValue(endY - startY, scrollMove, speed, easing)
 }
 
 export function getScrollTop() {


### PR DESCRIPTION
There were a few ways to go about this, but I decided to start with generalizing the tweening of values, then making the minimal change to allow `scrollToY` to take the scrolling element as an argument.

Another approach would be to add an animated scrollTo on `ScrollView` components, but that wouldn't help with non-constelation nodes.

It also might be valuable to export the abstracted `tweenValue` function, but I don't think that necessarily belongs in a `dom` module.

Also... since the easing isn't as predictable as a time-clamped version, it might be useful to allow a `finalCallback` or pass a `isDone` boolean to the `callback` when the tweening is done.  The first option is arguably cleaner but having two function arguments that do similar things might be odd.

closes #90 