### PR TITLE
Allow single module packages to be imported like peasant modules

### DIFF
--- a/packages/Image/src/index.native.tsx
+++ b/packages/Image/src/index.native.tsx
@@ -143,7 +143,7 @@ function getNonStyleProps(props: IProps) {
   return _omit(props, propsToOmit)
 }
 
-export default class Image extends React.PureComponent<IProps, void> {
+export class Image extends React.PureComponent<IProps, void> {
   static getSize = ReactNative.Image.getSize
   static prefetch = ReactNative.Image.prefetch
   static resolveAssetSource = ReactNative.Image.resolveAssetSource
@@ -190,3 +190,5 @@ export default class Image extends React.PureComponent<IProps, void> {
       : <ReactNative.Image {...propsWithoutStyle} style={style} />
   }
 }
+
+export default Image

--- a/packages/ScrollView/src/index.native.tsx
+++ b/packages/ScrollView/src/index.native.tsx
@@ -222,7 +222,7 @@ function hasContentStyleProps(props: IProps) {
     )
 }
 
-export default class ScrollView extends React.Component<IProps, void> {
+export class ScrollView extends React.Component<IProps, void> {
     private setAnimatedRef = (node) => {
         this.props.refNode(node ? node._component : node);
     }
@@ -249,3 +249,5 @@ export default class ScrollView extends React.Component<IProps, void> {
             : <ReactNative.ScrollView {...propsToPass} />
     }
 }
+
+export default ScrollView

--- a/packages/ScrollView/src/index.tsx
+++ b/packages/ScrollView/src/index.tsx
@@ -62,7 +62,7 @@ export interface IProps {
   scrollEnabled?: boolean,
 }
 
-//NOTES: other 
+//NOTES: other
 
 // const align = {
 //   left: 'flex-start',
@@ -214,7 +214,7 @@ function getNonStyleProps(props: IProps) {
   return _omit(props, propsToOmit)
 }
 
-export default class ScrollView extends React.Component<IProps, void> {
+export class ScrollView extends React.Component<IProps, void> {
   scrollView: HTMLElement
 
   static defaultProps = {
@@ -277,3 +277,5 @@ export default class ScrollView extends React.Component<IProps, void> {
     return glamorReact.createElement(this.props.tag, propsToPass)
   }
 }
+
+export default ScrollView

--- a/packages/Space/src/index.native.tsx
+++ b/packages/Space/src/index.native.tsx
@@ -13,7 +13,7 @@ function getStyleFromProps(props: IProps) {
   }
 }
 
-export default class Space extends React.PureComponent<IProps, void> {
+export class Space extends React.PureComponent<IProps, void> {
   render() {
     return <ReactNative.View style={getStyleFromProps(this.props)} />
   }
@@ -28,3 +28,5 @@ export class SPACE extends React.Component<IProps, void> {
     return <ReactNative.View style={getStyleFromProps(this.props)} />
   }
 }
+
+export default Space

--- a/packages/Space/src/index.tsx
+++ b/packages/Space/src/index.tsx
@@ -17,7 +17,7 @@ function getStyleFromProps(props: IProps) {
   }
 }
 
-export default class Space extends React.PureComponent<IProps, void> {
+export class Space extends React.PureComponent<IProps, void> {
   render() {
     return glamorReact.createElement('div', { css: getStyleFromProps(this.props) })
   }
@@ -32,3 +32,5 @@ export class SPACE extends React.Component<IProps, void> {
     return glamorReact.createElement('div', { css: getStyleFromProps(this.props) })
   }
 }
+
+export default Space

--- a/packages/Text/src/index.native.tsx
+++ b/packages/Text/src/index.native.tsx
@@ -63,7 +63,7 @@ function getNonStyleProps(props: IProps): any {
   return _omit(props, propsToOmit)
 }
 
-export default class Text extends React.PureComponent<IProps, void> {
+export class Text extends React.PureComponent<IProps, void> {
   _root: {
     setNativeProps: Function,
   }
@@ -102,3 +102,5 @@ export default class Text extends React.PureComponent<IProps, void> {
       )
   }
 }
+
+export default Text

--- a/packages/Text/src/index.tsx
+++ b/packages/Text/src/index.tsx
@@ -103,7 +103,7 @@ function getNonStyleProps(props: IProps): any {
   return _omit(props, propsToOmit)
 }
 
-export default class Text extends React.PureComponent<IProps, void> {
+export class Text extends React.PureComponent<IProps, void> {
   static defaultProps = {
     tag: 'span',
     // from https://bitsofco.de/the-new-system-font-stack/
@@ -125,3 +125,5 @@ export default class Text extends React.PureComponent<IProps, void> {
     return glamorReact.createElement(this.props.tag, propsToPass)
   }
 }
+
+export default Text

--- a/packages/TransitionGroupView/src/index.tsx
+++ b/packages/TransitionGroupView/src/index.tsx
@@ -22,7 +22,7 @@ export interface IState {
   transitionName: Object,
 }
 
-export default class TransitionGroupView extends React.Component<IProps, IState> {
+export class TransitionGroupView extends React.Component<IProps, IState> {
   static defaultProps = {
     component: View,
   }
@@ -80,3 +80,5 @@ export default class TransitionGroupView extends React.Component<IProps, IState>
     )
   }
 }
+
+export default TransitionGroupView


### PR DESCRIPTION
Currently only `Style_`, `Event_`, `Animate_` and `View` are able to imported as default modules, and "member" modules.

This allows all other packages to do the same, e.g. `import { Text } from 'constelation-Text'`

Don't know if this is necessary, but allows style preference for developers.